### PR TITLE
Make the output quiet. relates to AGJS-189

### DIFF
--- a/servers/activemqtest/server.sh
+++ b/servers/activemqtest/server.sh
@@ -21,12 +21,12 @@ fi
 
 if [ ! -f "$ACTIVEMQ_PATH-bin.tar.gz" ]; then
     echo $DOWNLOAD_URL
-    wget -c $DOWNLOAD_URL -P $BASE_DIR/
+    wget -q -c $DOWNLOAD_URL -P $BASE_DIR/
 fi
 
 if [ -f "$ACTIVEMQ_PATH-bin.tar.gz" ]; then
-    tar xzvf $ACTIVEMQ_PATH-bin.tar.gz
-    tar xzvf $BASE_DIR/conf.tar.gz -C apache-activemq-$ACTIVEMQ_VERSION/
+    tar xzf $ACTIVEMQ_PATH-bin.tar.gz
+    tar xzf $BASE_DIR/conf.tar.gz -C apache-activemq-$ACTIVEMQ_VERSION/
 else
     echo "The path does not contain a activemq distribution"
     exit 3

--- a/servers/vertxbustest/server.sh
+++ b/servers/vertxbustest/server.sh
@@ -19,11 +19,11 @@ if [ -d "$VERTX_PATH" ]; then
 fi
 
 if [ ! -f "$VERTX_PATH.tar.gz" ]; then
-    wget -c $DOWNLOAD_URL -P $BASE_DIR/
+    wget -q -c $DOWNLOAD_URL -P $BASE_DIR/
 fi
 
 if [ -f "$VERTX_PATH.tar.gz" ]; then
-    tar xzvf $VERTX_PATH.tar.gz
+    tar xzf $VERTX_PATH.tar.gz
 else
     echo "The path does not contain a vertx distribution"
 fi


### PR DESCRIPTION
basically, when running the tests, wget and tar like to end up in the stderr stream for some reason,  which then will fail our tests.  we didn't notice this since failOnError was false in grunt-shell.  but will the most recent version it defaults to true.

using a custom callback in grunt-shell and making wget and tar quiet will help this

this needs to be merged before https://github.com/aerogear/aerogear-js/pull/126 
